### PR TITLE
[18.0][FIX] web_m2x_options: Extend standard field props

### DIFF
--- a/web_m2x_options/__manifest__.py
+++ b/web_m2x_options/__manifest__.py
@@ -25,6 +25,11 @@
                 "web/static/src/views/fields/*",
                 "web_m2x_options/static/src/components/form.esm.js",
             ),
+            (
+                "after",
+                "web/static/src/views/fields/standard_field_props.js",
+                "web_m2x_options/static/src/views/fields/standard_field_props_patch.esm.js",
+            ),
             "web_m2x_options/static/src/components/base.xml",
         ]
     },

--- a/web_m2x_options/static/src/views/fields/standard_field_props_patch.esm.js
+++ b/web_m2x_options/static/src/views/fields/standard_field_props_patch.esm.js
@@ -1,0 +1,12 @@
+// This patch extends the standardFieldProps with additional optional properties
+// to support enhanced field customization and configurability in views.
+import {patch} from "@web/core/utils/patch";
+import {standardFieldProps} from "@web/views/fields/standard_field_props";
+
+// Add custom optional props to standardFieldProps
+patch(standardFieldProps, {
+    fieldColor: {type: String, optional: true},
+    fieldColorOptions: {type: Object, optional: true},
+    noSearchMore: {type: Boolean, optional: true},
+    searchLimit: {type: Number, optional: true},
+});


### PR DESCRIPTION
To fast-forward the process, we have created the Applied suggested changes https://github.com/OCA/web/pull/2961#pullrequestreview-2749405113